### PR TITLE
update clone instruction to use ssh, and current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Zecwallet-CLI does automatic note and utxo management, which means it doesn't al
     * Run `rustup update` to get the latest version of Rust if you already have it installed
 
 ```
-git clone https://github.com/adityapk00/lightwalletclient.git
+git clone git@github.com:adityapk00/zecwallet-light-cli.git
 cargo build --release
 ./target/release/zecwallet-cli
 ```


### PR DESCRIPTION
Well...   I thought the README was out of date, but now I am quite confused.
I've got no fewer than 3 names for two forks of this repo.

There's the original? archived, read-only, repo:

https://github.com/adityapk00/lightwalletclient.git

There's:

https://github.com/adityapk00/zecwallet-light-cli

And also:

https://github.com/adityapk00/zecwallet-lite-lib

The latter URL redirects to the former in my browser, but my fork gives the following URL:

`git@github.com:zancas/zecwallet-lite-lib.git`

I understand that I am using gits builtin protocol which runs atop ssh, but I am surprised that the basename at the end of the resource changes from `zecwallet-light-cli` to `zecwallet-lite-lib`.

Is this intentional?

Is it the intention that developers will clone and build from the archived read-only repo?
Is the name change from the "origin" repo, to forks intentional, or is it a side-effect of some name migration?