### PR TITLE
remove use and make name explicit where used

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::io::{Result, Error, ErrorKind};
-use std::sync::{Arc};
+use std::sync::Arc;
 use std::sync::mpsc::{channel, Sender, Receiver};
 use std::time::Duration;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::{Result, Error, ErrorKind};
 use std::sync::Arc;
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::time::Duration;
 
 use zecwalletlitelib::{commands, 
     lightclient::{self, LightClient, LightClientConfig},
@@ -260,7 +259,7 @@ fn command_loop(lightclient: Arc<LightClient>) -> (Sender<(String, Vec<String>)>
     let lc = lightclient.clone();
     std::thread::spawn(move || {
         loop {
-            match command_rx.recv_timeout(Duration::from_secs(5 * 60)) {
+            match command_rx.recv_timeout(std::time::Duration::from_secs(5 * 60)) {
                 Ok((cmd, args)) => {
                     let args = args.iter().map(|s| s.as_ref()).collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use log4rs::append::rolling_file::policy::compound::{
     roll::fixed_window::FixedWindowRoller,
 };
 
-use clap::{Arg, App};
 
 
 /// Build the Logging config
@@ -54,6 +53,7 @@ fn get_log_config(config: &LightClientConfig) -> Result<Config> {
 
 pub fn main() {
     // Get command line arguments
+    use clap::{Arg, App};
     let matches = App::new("Zecwallet CLI")
                     .version("1.0.0")
                     .arg(Arg::with_name("seed")

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ use log4rs::append::rolling_file::policy::compound::{
 };
 
 use rustyline::error::ReadlineError;
-use rustyline::Editor;
 
 use clap::{Arg, App};
 
@@ -183,7 +182,7 @@ fn startup(server: http::Uri, dangerous: bool, seed: Option<String>, first_sync:
 
 fn start_interactive(command_tx: Sender<(String, Vec<String>)>, resp_rx: Receiver<String>) {
     // `()` can be used when no completer is required
-    let mut rl = Editor::<()>::new();
+    let mut rl = rustyline::Editor::<()>::new();
 
     println!("Ready!");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,6 @@ use log4rs::append::rolling_file::policy::compound::{
     roll::fixed_window::FixedWindowRoller,
 };
 
-use rustyline::error::ReadlineError;
-
 use clap::{Arg, App};
 
 
@@ -234,13 +232,13 @@ fn start_interactive(command_tx: Sender<(String, Vec<String>)>, resp_rx: Receive
                     break;
                 }
             },
-            Err(ReadlineError::Interrupted) => {
+            Err(rustyline::error::ReadlineError::Interrupted) => {
                 println!("CTRL-C");
                 info!("CTRL-C");
                 println!("{}", send_command("save".to_string(), vec![]));
                 break
             },
-            Err(ReadlineError::Eof) => {
+            Err(rustyline::error::ReadlineError::Eof) => {
                 println!("CTRL-D");
                 info!("CTRL-D");
                 println!("{}", send_command("save".to_string(), vec![]));


### PR DESCRIPTION
This commit suggests a readability enhancement.
Removing the "use" directive, and making the
rustyline::Editor usage explicit at the call site,
allows the reader to look in one less place.

If the pattern seems worth pursuing we could eliminate more "use" statements.