### PR TITLE
[#86] Add support for providing `--data-dir` to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,5 @@ Here are some CLI arguments you can pass to `zecwallet-cli`. Please run `zecwall
     * Example: `./zecwallet-cli --seed "twenty four words seed phrase"`
  * `--recover`: Attempt to recover the seed phrase from a corrupted wallet
  
+ * `--data-dir`: uses the specified path as data directory.
+    * Example: `./zecwallet-cli --server 127.0.0.1:9067 --data-dir /Users/ZecWalletRocks/my-test-wallet` will use the provided directory to store `zecwallet-light-wallet.dat` and logs. If the provided directory does not exist, it will create it.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,8 @@ pub fn main() {
 
     let maybe_server = matches.value_of("server").map(|s| s.to_string());
 
+    let maybe_data_dir = matches.value_of("data-dir").map(|s| s.to_string());
+
     let seed = matches.value_of("seed").map(|s| s.to_string());
     let maybe_birthday = matches.value_of("birthday");
 
@@ -60,7 +62,7 @@ pub fn main() {
 
     let nosync = matches.is_present("nosync");
 
-    let startup_chan = startup(server, seed, birthday, !nosync, command.is_none());
+    let startup_chan = startup(server, seed, birthday, maybe_data_dir ,!nosync, command.is_none());
     let (command_tx, resp_rx) = match startup_chan {
         Ok(c) => c,
         Err(e) => {

--- a/lib/src/lightclient/lightclient_config.rs
+++ b/lib/src/lightclient/lightclient_config.rs
@@ -15,9 +15,10 @@ use log4rs::{
     Config,
 };
 use tokio::runtime::Runtime;
+use zcash_address::Network;
 use zcash_primitives::{
-    consensus::Network,
-    constants::{mainnet, regtest, testnet},
+    consensus::{self, BlockHeight, NetworkUpgrade, Parameters},
+    constants::{self},
 };
 
 use crate::{grpc_connector::GrpcConnector, lightclient::checkpoints};
@@ -25,7 +26,7 @@ use crate::{grpc_connector::GrpcConnector, lightclient::checkpoints};
 pub const DEFAULT_SERVER: &str = "https://lwdv3.zecwallet.co";
 pub const WALLET_NAME: &str = "zecwallet-light-wallet.dat";
 pub const LOGFILE_NAME: &str = "zecwallet-light-wallet.debug.log";
-pub const ANCHOR_OFFSET: [u32; 5] = [4, 0, 0, 0, 0];
+pub const DEFAULT_ANCHOR_OFFSET: u32 = 1;
 pub const MAX_REORG: usize = 100;
 pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", target_os = "android")) {
     0
@@ -33,77 +34,132 @@ pub const GAP_RULE_UNUSED_ADDRESSES: usize = if cfg!(any(target_os = "ios", targ
     5
 };
 
+// Marker struct for the production network.
+#[derive(PartialEq, Copy, Clone, Debug)]
+pub struct UnitTestNetwork;
+
+impl Parameters for UnitTestNetwork {
+    fn activation_height(&self, nu: NetworkUpgrade) -> Option<BlockHeight> {
+        match nu {
+            NetworkUpgrade::Overwinter => Some(BlockHeight::from(1)),
+            NetworkUpgrade::Sapling => Some(BlockHeight::from(1)),
+            NetworkUpgrade::Blossom => Some(BlockHeight::from(1)),
+            NetworkUpgrade::Heartwood => Some(BlockHeight::from(1)),
+            NetworkUpgrade::Canopy => Some(BlockHeight::from(1)),
+            NetworkUpgrade::Nu5 => Some(BlockHeight::from(1)),
+            #[cfg(feature = "zfuture")]
+            NetworkUpgrade::ZFuture => None,
+        }
+    }
+
+    fn coin_type(&self) -> u32 {
+        constants::mainnet::COIN_TYPE
+    }
+
+    fn hrp_sapling_extended_spending_key(&self) -> &str {
+        constants::mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY
+    }
+
+    fn hrp_sapling_extended_full_viewing_key(&self) -> &str {
+        constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY
+    }
+
+    fn hrp_sapling_payment_address(&self) -> &str {
+        constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS
+    }
+
+    fn b58_pubkey_address_prefix(&self) -> [u8; 2] {
+        constants::mainnet::B58_PUBKEY_ADDRESS_PREFIX
+    }
+
+    fn b58_script_address_prefix(&self) -> [u8; 2] {
+        constants::mainnet::B58_SCRIPT_ADDRESS_PREFIX
+    }
+
+    fn address_network(&self) -> Option<zcash_address::Network> {
+        Some(zcash_address::Network::Main)
+    }
+}
+
+pub const UNITTEST_NETWORK: UnitTestNetwork = UnitTestNetwork;
+
 #[derive(Clone, Debug)]
-pub struct LightClientConfig {
+pub struct LightClientConfig<P> {
     pub server: http::Uri,
     pub chain_name: String,
     pub sapling_activation_height: u64,
-    pub anchor_offset: [u32; 5],
+    pub anchor_offset: u32,
     pub monitor_mempool: bool,
     pub data_dir: Option<String>,
+    pub params: P,
 }
 
-impl LightClientConfig {
+impl<P: consensus::Parameters> LightClientConfig<P> {
     // Create an unconnected (to any server) config to test for local wallet etc...
-    pub fn create_unconnected(chain_name: String, dir: Option<String>) -> LightClientConfig {
+    pub fn create_unconnected(params: P, dir: Option<String>) -> LightClientConfig<P> {
         LightClientConfig {
             server: http::Uri::default(),
-            chain_name: chain_name,
+            chain_name: params.hrp_sapling_payment_address().to_string(),
             sapling_activation_height: 1,
             monitor_mempool: false,
-            anchor_offset: [4u32; 5],
+            anchor_offset: 1,
             data_dir: dir,
+            params: params.clone(),
         }
     }
-   
-    pub fn create_on_data_dir(server: http::Uri, data_dir: Option<String>) -> io::Result<(LightClientConfig, u64)> {
+
+    pub fn create(params: P, server: http::Uri, data_dir: Option<String>) -> io::Result<(LightClientConfig<P>, u64)> {
         use std::net::ToSocketAddrs;
 
-        let lc = Runtime::new().unwrap().block_on(async move {
-            // Test for a connection first
-            format!("{}:{}", server.host().unwrap(), server.port().unwrap())
-                .to_socket_addrs()?
-                .next()
-                .ok_or(std::io::Error::new(
-                    ErrorKind::ConnectionRefused,
-                    "Couldn't resolve server!",
-                ))?;
+        let s = server.clone();
+        if let Ok((chain_name, sapling_activation_height, block_height)) =
+            Runtime::new().unwrap().block_on(async move {
+                // Test for a connection first
+                format!("{}:{}", server.host().unwrap(), server.port().unwrap())
+                    .to_socket_addrs()?
+                    .next()
+                    .ok_or(std::io::Error::new(
+                        ErrorKind::ConnectionRefused,
+                        "Couldn't resolve server!",
+                    ))?;
 
-            // Do a getinfo first, before opening the wallet
-            let info = GrpcConnector::get_info(server.clone())
-                .await
-                .map_err(|e| std::io::Error::new(ErrorKind::ConnectionRefused, e))?;
+                // Do a getinfo first, before opening the wallet
+                let info = GrpcConnector::get_info(server.clone())
+                    .await
+                    .map_err(|e| std::io::Error::new(ErrorKind::ConnectionRefused, e))?;
+
+                Ok::<_, std::io::Error>((info.chain_name, info.sapling_activation_height, info.block_height))
+            })
+        {
 
             // Create a Light Client Config
             let config = LightClientConfig {
-                server,
-                chain_name: info.chain_name,
-                monitor_mempool: true,
-                sapling_activation_height: info.sapling_activation_height,
-                anchor_offset: ANCHOR_OFFSET,
+                server: s,
+                chain_name,
+                monitor_mempool: false,
+                sapling_activation_height,
+                anchor_offset: DEFAULT_ANCHOR_OFFSET,
                 data_dir: data_dir,
+                params,
             };
 
-            Ok((config, info.block_height))
-        });
 
-        lc
-    }
-
-    pub fn create(server: http::Uri) -> io::Result<(LightClientConfig,u64)> {
-        Self::create_on_data_dir(server, None)
+            Ok((config, block_height))
+        } else {
+            panic!("Couldn't get network");
+        }
     }
 
     pub fn set_data_dir(&mut self, dir_str: String) {
         self.data_dir = Some(dir_str);
     }
 
-    pub fn get_params(&self) -> Network {
-        match self.chain_name.as_str() {
-            "main" => Network::MainNetwork,
-            "test" => Network::TestNetwork,
-            _ => panic!("Unknown network"),
-        }
+    pub fn get_params(&self) -> P {
+        self.params.clone()
+    }
+
+    pub fn get_network(&self) -> Network {
+        self.params.address_network().unwrap_or(Network::Main).clone()
     }
 
     /// Build the Logging config
@@ -154,9 +210,9 @@ impl LightClientConfig {
                 };
 
                 match &self.chain_name[..] {
-                    "main" => {}
-                    "test" => zcash_data_location.push("testnet3"),
-                    "regtest" => zcash_data_location.push("regtest"),
+                    "zs" | "main" => {}
+                    "ztestsapling" | "test" => zcash_data_location.push("testnet3"),
+                    "zregtestsapling" | "regtest" => zcash_data_location.push("regtest"),
                     c => panic!("Unknown chain {}", c),
                 };
             }
@@ -249,7 +305,7 @@ impl LightClientConfig {
         }
 
         info!("Getting sapling tree from LightwalletD at height {}", height);
-        match GrpcConnector::get_sapling_tree(self.server.clone(), height).await {
+        match GrpcConnector::get_merkle_tree(self.server.clone(), height).await {
             Ok(tree_state) => {
                 let hash = tree_state.hash.clone();
                 let tree = tree_state.tree.clone();
@@ -286,64 +342,34 @@ impl LightClientConfig {
     }
 
     pub fn get_coin_type(&self) -> u32 {
-        match &self.chain_name[..] {
-            "main" => mainnet::COIN_TYPE,
-            "test" => testnet::COIN_TYPE,
-            "regtest" => regtest::COIN_TYPE,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.coin_type()
     }
 
     pub fn hrp_sapling_address(&self) -> &str {
-        match &self.chain_name[..] {
-            "main" => mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            "test" => testnet::HRP_SAPLING_PAYMENT_ADDRESS,
-            "regtest" => regtest::HRP_SAPLING_PAYMENT_ADDRESS,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.hrp_sapling_payment_address()
     }
 
     pub fn hrp_sapling_private_key(&self) -> &str {
-        match &self.chain_name[..] {
-            "main" => mainnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            "test" => testnet::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            "regtest" => regtest::HRP_SAPLING_EXTENDED_SPENDING_KEY,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.hrp_sapling_extended_spending_key()
     }
 
     pub fn hrp_sapling_viewing_key(&self) -> &str {
-        match &self.chain_name[..] {
-            "main" => mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            "test" => testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            "regtest" => regtest::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.hrp_sapling_extended_full_viewing_key()
     }
 
     pub fn base58_pubkey_address(&self) -> [u8; 2] {
-        match &self.chain_name[..] {
-            "main" => mainnet::B58_PUBKEY_ADDRESS_PREFIX,
-            "test" => testnet::B58_PUBKEY_ADDRESS_PREFIX,
-            "regtest" => regtest::B58_PUBKEY_ADDRESS_PREFIX,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.b58_pubkey_address_prefix()
     }
 
     pub fn base58_script_address(&self) -> [u8; 2] {
-        match &self.chain_name[..] {
-            "main" => mainnet::B58_SCRIPT_ADDRESS_PREFIX,
-            "test" => testnet::B58_SCRIPT_ADDRESS_PREFIX,
-            "regtest" => regtest::B58_SCRIPT_ADDRESS_PREFIX,
-            c => panic!("Unknown chain {}", c),
-        }
+        self.params.b58_script_address_prefix()
     }
 
     pub fn base58_secretkey_prefix(&self) -> [u8; 1] {
         match &self.chain_name[..] {
-            "main" => [0x80],
-            "test" => [0xEF],
-            "regtest" => [0xEF],
+            "zs" | "main" => [0x80],
+            "ztestsapling" => [0xEF],
+            "zregtestsapling" => [0xEF],
             c => panic!("Unknown chain {}", c),
         }
     }


### PR DESCRIPTION
This PR adds functionality to the interactive CLI to support using a different data directory than Zcash's default.

This allows users to use many wallet files without the need of being renaming them or risking to delete or overwrite them by mistake.

It also opens the possibility of doing CLI manual integration tests with servers like lightwalletd in "darkside" mode and reproduce different reorg scenarios without fiddling with the developers' main zcash folder and preserving test data for diagnosis. 
